### PR TITLE
Update README.md (fix incorrect option name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ yarn add simple-jsonp-promise
 ``` bash
 import jsonp from 'simple-jsonp-promise'
 let options = {
-        params:{
+        data: {
             a : 1,
             b : 2
         },


### PR DESCRIPTION
Fix `options.params` to `options.data` according to the source code (https://github.com/liziqiang/simple-jsonp-promise/blob/master/src/index.js#L22)